### PR TITLE
sonar cloud: round 1

### DIFF
--- a/src/auth/AuthContext.test.tsx
+++ b/src/auth/AuthContext.test.tsx
@@ -74,7 +74,7 @@ function wrapper(client: SupabaseClient) {
 describe('AuthProvider', () => {
   beforeEach(() => {
     // window.location is needed by the OAuth call.
-    Object.defineProperty(window, 'location', {
+    Object.defineProperty(globalThis, 'location', {
       value: { origin: 'http://localhost', pathname: '/' },
       writable: true,
     });

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -34,7 +34,7 @@ interface AuthProviderProps {
   client?: SupabaseClient;
 }
 
-export function AuthProvider({ children, client }: AuthProviderProps) {
+export function AuthProvider({ children, client }: Readonly<AuthProviderProps>) {
   const supabase = client ?? defaultSupabase;
   const [session, setSession] = useState<Session | null>(null);
   const [loading, setLoading] = useState(true);
@@ -90,7 +90,7 @@ export function AuthProvider({ children, client }: AuthProviderProps) {
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
-        redirectTo: window.location.origin + window.location.pathname,
+        redirectTo: globalThis.location.origin + globalThis.location.pathname,
       },
     });
     return { error: error ?? null };

--- a/src/components/AccountPage.tsx
+++ b/src/components/AccountPage.tsx
@@ -45,7 +45,7 @@ export default function AccountPage({
   onBack,
   onLoad,
   onScenariosChange,
-}: AccountPageProps) {
+}: Readonly<AccountPageProps>) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editName, setEditName] = useState('');
   const [renaming, setRenaming] = useState(false);
@@ -107,9 +107,9 @@ export default function AccountPage({
               My Scenarios
             </Typography>
             <Typography variant="body2" sx={{ color: '#5A5A7A' }}>
-              {scenarios.length === 0
-                ? 'No saved scenarios yet'
-                : `${String(scenarios.length)} saved scenario${scenarios.length === 1 ? '' : 's'}`}
+              {scenarios.length === 0 && 'No saved scenarios yet'}
+              {scenarios.length === 1 && '1 saved scenario'}
+              {scenarios.length > 1 && `${String(scenarios.length)} saved scenarios`}
             </Typography>
           </Box>
         </Box>
@@ -240,7 +240,7 @@ export default function AccountPage({
                         variant="outlined"
                         sx={{ fontSize: '0.72rem' }}
                       />
-                      {scenario.income != null && (
+                      {scenario.income && (
                         <Chip
                           label={`Income: ${formatCurrency(scenario.income)}`}
                           size="small"
@@ -271,7 +271,7 @@ export default function AccountPage({
                       onClick={() => {
                         startEdit(scenario);
                       }}
-                      disabled={editingId !== null}
+                      disabled={!!editingId}
                       aria-label="Rename scenario"
                       sx={{ color: '#5A5A7A' }}
                     >

--- a/src/components/AmortizationTable.tsx
+++ b/src/components/AmortizationTable.tsx
@@ -74,7 +74,7 @@ export default function AmortizationTable({
   onStartMonthChange,
   rows,
   startMonth,
-}: AmortizationTableProps) {
+}: Readonly<AmortizationTableProps>) {
   const yearlyGroups = groupRowsByYear(rows);
   const [expandAll, setExpandAll] = useState(false);
   const [expandedYears, setExpandedYears] = useState<number[]>(() => {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -39,7 +39,7 @@ export default function Header({
   onAccountClick,
   savedScenarios = [],
   onLoadScenario,
-}: HeaderProps) {
+}: Readonly<HeaderProps>) {
   const { user, loading, signOut } = useAuth();
 
   // Avatar / account dropdown

--- a/src/components/LoanDetailsForm.tsx
+++ b/src/components/LoanDetailsForm.tsx
@@ -32,7 +32,7 @@ interface LoanDetailsFormProps {
 }
 
 function formatPrincipalInput(value: string): string {
-  const digits = value.replace(/[^0-9.]/g, '');
+  const digits = value.replaceAll(/[^0-9.]/g, '');
   const parts = digits.split('.');
   if (parts[0]) {
     parts[0] = Number(parts[0]).toLocaleString('en-US');
@@ -45,7 +45,7 @@ export default function LoanDetailsForm({
   onSaveRequest,
   defaultValues,
   isLoggedIn = false,
-}: LoanDetailsFormProps) {
+}: Readonly<LoanDetailsFormProps>) {
   const [principal, setPrincipal] = useState('10,000');
   const [interestRate, setInterestRate] = useState('5');
   const [loanTerm, setLoanTerm] = useState('10');
@@ -80,8 +80,8 @@ export default function LoanDetailsForm({
     setLoanTerm(String(defaultValues.loanTerm));
     setTermUnit(defaultValues.termUnit);
     setRepaymentPlan(defaultValues.repaymentPlan);
-    setIncome(defaultValues.income != null ? String(defaultValues.income) : '');
-    setFamilySize(defaultValues.familySize != null ? String(defaultValues.familySize) : '');
+    setIncome(defaultValues.income ? String(defaultValues.income) : '');
+    setFamilySize(defaultValues.familySize ? String(defaultValues.familySize) : '');
     setErrors({});
     /* eslint-enable react-hooks/set-state-in-effect */
 
@@ -93,7 +93,7 @@ export default function LoanDetailsForm({
     _: React.MouseEvent<HTMLElement>,
     newUnit: 'months' | 'years' | null,
   ) => {
-    if (newUnit !== null) {
+    if (newUnit) {
       setTermUnit(newUnit);
     }
   };
@@ -102,7 +102,7 @@ export default function LoanDetailsForm({
   _: React.MouseEvent<HTMLElement>,
   newPlan: 'standard' | 'ibr' | 'icr' | 'paye' | null,
 ) => {
-  if (newPlan !== null) {
+  if (newPlan) {
     setRepaymentPlan(newPlan);
     if (newPlan === 'standard') {
       setCompareToStandard(false);
@@ -111,41 +111,47 @@ export default function LoanDetailsForm({
 };
 
   const buildFormValues = (): FormValues | null => {
-    const principalNum = parseFloat(principal.replace(/,/g, ''));
-    const rateNum = parseFloat(interestRate);
-    const termNum = parseFloat(loanTerm);
-    const incomeNum = parseFloat(income.replace(/,/g, ''));
-    const familySizeNum = parseFloat(familySize);
+    const principalNum = Number.parseFloat(principal.replaceAll(/,/g, ''));
+    const rateNum = Number.parseFloat(interestRate);
+    const termNum = Number.parseFloat(loanTerm);
+    const incomeNum = Number.parseFloat(income.replaceAll(/,/g, ''));
+    const familySizeNum = Number.parseFloat(familySize);
 
     const newErrors: typeof errors = {};
 
-    if (isNaN(principalNum)) newErrors.principal = 'Principal is required';
+    // principal
+    if (Number.isNaN(principalNum)) newErrors.principal = 'Principal is required';
     else if (principalNum === 0)
       newErrors.principal = 'Principal must be greater than 0';
     else if (principalNum > 10_000_000_000)
       newErrors.principal = 'Principal too large';
 
-    if (isNaN(rateNum)) newErrors.interestRate = 'Interest rate is required';
+    // interest rate
+    if (Number.isNaN(rateNum)) newErrors.interestRate = 'Interest rate is required';
     else if (rateNum > 100)
       newErrors.interestRate = 'Interest rate too large';
 
+    // loan term
     let termValidationMonths = termNum;
     if (termUnit === 'years') termValidationMonths *= 12;
 
-    if (isNaN(termValidationMonths))
+    if (Number.isNaN(termValidationMonths))
       newErrors.loanTerm = 'Loan term is required';
     else if (termValidationMonths === 0)
       newErrors.loanTerm = 'Loan term must be greater than 0';
     else if (termValidationMonths > 600)
       newErrors.loanTerm = 'Loan term too large';
 
+    // idr: 
     if (repaymentPlan !== 'standard') {
-      if (isNaN(incomeNum) || incomeNum === 0)
+      // idr: income
+      if (Number.isNaN(incomeNum) || incomeNum === 0)
         newErrors.income = 'Income must be greater than 0';
       else if (incomeNum > 10_000_000_000)
         newErrors.income = 'Income too large';
 
-      if (isNaN(familySizeNum) || familySizeNum < 1)
+      // idr: family size
+      if (Number.isNaN(familySizeNum) || familySizeNum < 1)
         newErrors.familySize = 'Family size must be at least 1';
       else if (familySizeNum > 50)
         newErrors.familySize = 'Family size too large';
@@ -165,9 +171,9 @@ export default function LoanDetailsForm({
       termUnit,
       repaymentPlan,
       income:
-        repaymentPlan !== 'standard' && !isNaN(incomeNum) ? incomeNum : undefined,
+        repaymentPlan !== 'standard' && !Number.isNaN(incomeNum) ? incomeNum : undefined,
       familySize:
-        repaymentPlan !== 'standard' && !isNaN(familySizeNum)
+        repaymentPlan !== 'standard' && !Number.isNaN(familySizeNum)
           ? familySizeNum
           : undefined,
       compareToStandard,
@@ -246,7 +252,7 @@ export default function LoanDetailsForm({
           fullWidth
           value={loanTerm}
           onChange={(e) => {
-            setLoanTerm(e.target.value.replace(/[^0-9]/g, ''));
+            setLoanTerm(e.target.value.replaceAll(/\D/g, ''));
           }}
           placeholder="10"
           error={!!errors.loanTerm}
@@ -378,7 +384,7 @@ export default function LoanDetailsForm({
           fullWidth
           value={interestRate}
           onChange={(e) => {
-            setInterestRate(e.target.value.replace(/[^0-9.]/g, ''));
+            setInterestRate(e.target.value.replaceAll(/[^0-9.]/g, ''));
           }}
           placeholder="5.0"
           error={!!errors.interestRate}
@@ -417,7 +423,7 @@ export default function LoanDetailsForm({
           fullWidth
           value={income}
           onChange={(e) => {
-            const value = e.target.value.replace(/[^0-9,]/g, '');
+            const value = e.target.value.replaceAll(/[^0-9,]/g, '');
             setIncome(value);
           }}
           placeholder="50000"
@@ -454,7 +460,7 @@ export default function LoanDetailsForm({
           fullWidth
           value={familySize}
           onChange={(e) => {
-            setFamilySize(e.target.value.replace(/[^0-9]/g, ''));
+            setFamilySize(e.target.value.replaceAll(/\D/g, ''));
           }}
           placeholder="1"
           error={!!errors.familySize}

--- a/src/components/LoginPage.test.tsx
+++ b/src/components/LoginPage.test.tsx
@@ -23,16 +23,16 @@ function createFakeClient() {
 function Wrap({
   client,
   children,
-}: {
+}: Readonly<{
   client: SupabaseClient;
   children: ReactNode;
-}) {
+}>) {
   return <AuthProvider client={client}>{children}</AuthProvider>;
 }
 
 describe('LoginPage', () => {
   beforeEach(() => {
-    Object.defineProperty(window, 'location', {
+    Object.defineProperty(globalThis, 'location', {
       value: { origin: 'http://localhost', pathname: '/' },
       writable: true,
     });

--- a/src/components/LoginPage.tsx
+++ b/src/components/LoginPage.tsx
@@ -19,7 +19,7 @@ interface LoginPageProps {
 
 type Mode = 'signin' | 'signup';
 
-export default function LoginPage({ onClose }: LoginPageProps) {
+export default function LoginPage({ onClose }: Readonly<LoginPageProps>) {
   const { signInWithPassword, signUpWithPassword, signInWithGoogle } =
     useAuth();
   const [mode, setMode] = useState<Mode>('signin');

--- a/src/components/ResultsSummaryIDR.tsx
+++ b/src/components/ResultsSummaryIDR.tsx
@@ -18,7 +18,7 @@ function formatCurrency(value: number): string {
 export default function ResultsSummary({
   repaymentPlan,
   monthlyPayment,
-}: ResultsSummaryProps) {
+}: Readonly<ResultsSummaryProps>) {
   // Forgiveness Eligibility (including PSLF) Calculations
   let forgivenessTermYears = 25;
   const forgivenessTermYearsPSLF = 10;

--- a/src/components/ResultsSummaryStd.tsx
+++ b/src/components/ResultsSummaryStd.tsx
@@ -24,7 +24,7 @@ export default function ResultsSummary({
   totalInterest,
   totalCost,
   termMonths,
-}: ResultsSummaryProps) {
+}: Readonly<ResultsSummaryProps>) {
   const principalPercent =
     totalCost > 0 ? Math.round((totalPaid / totalCost) * 100) : 0;
   const interestPercent = 100 - principalPercent;

--- a/src/components/SaveScenarioDialog.tsx
+++ b/src/components/SaveScenarioDialog.tsx
@@ -18,7 +18,7 @@ export default function SaveScenarioDialog({
   open,
   onClose,
   onSave,
-}: SaveScenarioDialogProps) {
+}: Readonly<SaveScenarioDialogProps>) {
   const [name, setName] = useState('');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 /// <reference types="vitest" />
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import path from 'path'
+import path from 'node:path'
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => ({


### PR DESCRIPTION
After running through Sonar Cloud, this fixes:

There are 41 issues identified in total.

High: Refactor this code to not nest functions more than 4 levels deep.
There is a deep nesting of functions in the amortization code.
The code could be refactored but already reads reasonably. As such this issue will not be updated.
High: Refactor this function to reduce its Cognitive Complexity from 21 to the 15 allowed.
There are a lot of if statements in the error checking code complex.
The code is still readable as the specific field each if statement.checks is straightforward. Additional comments were added for clarity but no action will be taken regarding the code structure.
Medium: Extract this nested ternary operation into an independent statement.
The account page has a nested ternary to address making a word plural when a value is > 1.
Refactor the code to make it more readable.
Medium: Prefer `Number.parseFloat` over `parseFloat`.
There are 5 locations where a less desirable function is used.
Update the function call to the preferred name.
Medium: Prefer `Number.isNaN` over `isNaN`.
There are 7 locations where the less desirable function is used.
Updated the function call to the preferred name.
Medium: Prefer `node:path` over `path`.
There is a location in the config where `path` is used.
Update the config to `node:path`
Low: Prefer `globalThis` over `window`.
There are 4 locations where the less desired name is used.
Update the files to use the preferred name.
Low: Mark the props of the component as read-only.
There are 10 locations where a read-only declaration can be used.
Update the files to mark the props as read-only.
Low: Prefer `String#replaceAll()` over `String#replace()`.
There are 7 locations where the less desirable function is called.
Update the code to the preferred function.
Low: Unexpected negated condition.
There are two locations where `!= null` is used.
Rewrite these so they’re less confusing.
Low: Use concise character class syntax '\D' instead of '[^0-9]'.
There are two locations where the digit character class can be used instead of 0-9.
The more concise \D will be updated in the code.
